### PR TITLE
chore: 提供一些基本的代码片段用于快速创建组件

### DIFF
--- a/.vscode/component.code-snippets
+++ b/.vscode/component.code-snippets
@@ -1,0 +1,47 @@
+{
+  "component-entry": {
+    "prefix": "cpen",
+    "body": [
+      "import ${2:${TM_DIRECTORY/.*[\\\\|\\/]+(.*)/_${1:/pascalcase}/}} from './${1:${TM_DIRECTORY/.*[\\\\|\\/]+(.*)/${1:/pascalcase}/}}';",
+      "",
+      "import './style/index.js';",
+      "",
+      "export type { ${TM_DIRECTORY/.*[\\\\|\\/]+(.*)/${1:/pascalcase}/}Props } from './${TM_DIRECTORY/.*[\\\\|\\/]+(.*)/${1:/pascalcase}/}';",
+      "",
+      "export * from './type';",
+      "",
+      "export const ${3:${TM_DIRECTORY/.*[\\\\|\\/]+(.*)/${1:/pascalcase}/}} = ${2:${TM_DIRECTORY/.*[\\\\|\\/]+(.*)/_${1:/pascalcase}/}};",
+      "",
+      "export default ${3:${TM_DIRECTORY/.*[\\\\|\\/]+(.*)/${1:/pascalcase}/}};",
+      ""
+    ],
+    "scope": "javascript,typescript,typescriptreact,javascriptreact",
+    "description": "组件的导入入口快捷设置"
+  },
+  "component-base": {
+    "prefix": "cbase",
+    "body": [
+      "import React, { forwardRef, useContext, useMemo } from 'react';",
+      "import { ConfigContext } from '../config-provider';",
+      "import type { StyledProps } from '../common';",
+      "import type { Td${TM_FILENAME_BASE}Props } from './type';",
+      "",
+      "export interface ${TM_FILENAME_BASE}Props extends Td${TM_FILENAME_BASE}Props, StyledProps {}",
+      "",
+      "const ${TM_FILENAME_BASE} = forwardRef<React.LegacyRef<${1:any}>, ${TM_FILENAME_BASE}Props>((props, ref) => {",
+      "  const { ${2} } = props;",
+      "  const { classPrefix } = useContext(ConfigContext);",
+      "  const name = useMemo(() => `\\${classPrefix}-${TM_DIRECTORY/.*[\\\\|\\/]+(.*)/$1/}`, [classPrefix]);",
+      "",
+      "  return ${3:null};",
+      "});",
+      "",
+      "${TM_FILENAME_BASE}.displayName = '${TM_FILENAME_BASE}';",
+      "",
+      "export default ${TM_FILENAME_BASE};",
+      ""
+    ],
+    "scope": "javascript,typescript,typescriptreact,javascriptreact",
+    "description": "提供组件内容的基本形状"
+  }
+}


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄
请阅读并遵循 [TDesign 贡献指南](https://github.com/Tencent/tdesign/blob/main/docs/contributing.md)，填写以下 pull request 的信息。
PR 在维护者审核通过后会合并，谢谢！
-->

### 🤔 这个 PR 的性质是？

- [ ] 日常 bug 修复
- [ ] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [x] 其他

### 🔗 相关 Issue

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->

### 💡 需求背景和解决方案

在创建组件后，脚手架会帮我们导入一些基础文件，我们通过人为约定创建入口 index entry， 组件名字 CamelCase.tsx 
当前代码片段基于约定规则生成基本片段内容。免除一些重复工作

### 📝 更新日志

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
-->
no breaking change

- [x] 本条 PR 不需要纳入 Changelog

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供
