### PR TITLE
fix(steps): inconsistent rendering between string and number when the props of 'current' is a string

### DIFF
--- a/src/steps/StepItem.tsx
+++ b/src/steps/StepItem.tsx
@@ -60,7 +60,7 @@ const StepItem: FC<StepItemProps> = (props) => {
   const dot = useMemo(() => theme === StepThemeEnum.DOT, [theme]);
   const currentStatus = useMemo(() => {
     if (status !== 'default') return status;
-    if (index === current) return stepsStatus;
+    if (index === +current) return stepsStatus;
     if (index < +current) return 'finish';
     return status;
   }, [index, current, stepsStatus, status]);

--- a/src/steps/_example/horizontal.tsx
+++ b/src/steps/_example/horizontal.tsx
@@ -3,7 +3,7 @@ import { Steps, StepItem } from 'tdesign-mobile-react';
 import { CartIcon } from 'tdesign-icons-react';
 
 export default function StepsDemo() {
-  const [first, setFirst] = useState(1);
+  const [first, setFirst] = useState<number | string>('1');
   const [second, setSecond] = useState(1);
   const [third, setThird] = useState(1);
   const options = {
@@ -13,7 +13,7 @@ export default function StepsDemo() {
   };
 
   const count = 4;
-  const onFirstChange = (current: number) => {
+  const onFirstChange = (current: number | string) => {
     setFirst(current);
   };
   const onSecondChange = (current: number) => {
@@ -23,14 +23,17 @@ export default function StepsDemo() {
     setThird(current);
   };
 
-  const getTitle = (type: 'first' | 'second' | 'third', index: number) => {
-    if (index === options[type]) {
+  const getTitle = (type: 'first' | 'second' | 'third', index: number | string) => {
+    const numIndex = Number(index);
+    const currentValue = Number(options[type]);
+
+    if (numIndex === currentValue) {
       return '当前步骤';
     }
-    if (index < options[type]) {
+    if (numIndex < currentValue) {
       return '已完成';
     }
-    if (index > options[type]) {
+    if (numIndex > currentValue) {
       return '未完成';
     }
   };


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄
请阅读并遵循 [TDesign 贡献指南](https://github.com/Tencent/tdesign/blob/main/docs/contributing.md)，填写以下 pull request 的信息。
PR 在维护者审核通过后会合并，谢谢！
-->

### 🤔 这个 PR 的性质是？

- [x] 日常 bug 修复
- [ ] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->

### 💡 需求背景和解决方案

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->

### 📝 更新日志

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
-->

fix(steps): inconsistent rendering between string and number when the props of 'current' is a string


- [ ] 本条 PR 不需要纳入 Changelog

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供


### 修复描述

#### 修复前
<img width="2028" height="1102" alt="image" src="https://github.com/user-attachments/assets/0feb1805-2b64-4282-bd62-64572489b9e4" />

#### 修复后
<img width="2048" height="956" alt="image" src="https://github.com/user-attachments/assets/2140d6a3-2e1a-4a1b-8ad7-bfcc8af418a2" />

#### Number类型情况
<img width="2050" height="1078" alt="image" src="https://github.com/user-attachments/assets/c84a41ed-61ea-4776-8b88-c566044ce11f" />
